### PR TITLE
Feat : 이전 채팅 내용 가져오는 로직 구현

### DIFF
--- a/src/main/java/com/promptoven/chatservice/application/ChatMessageService.java
+++ b/src/main/java/com/promptoven/chatservice/application/ChatMessageService.java
@@ -4,5 +4,6 @@ import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import reactor.core.publisher.Flux;
 
 public interface ChatMessageService {
+
     Flux<ChatMessageResponseDto> getMessageByRoomId(String roomId);
 }

--- a/src/main/java/com/promptoven/chatservice/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/promptoven/chatservice/application/ChatMessageServiceImpl.java
@@ -7,7 +7,6 @@ import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.core.ChangeStreamEvent;
@@ -18,7 +17,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageServiceImpl implements ChatMessageService {
@@ -29,8 +27,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     @Override
     public Flux<ChatMessageResponseDto> getMessageByRoomId(String roomId) {
 
-        log.info("getNewChatMessageByRoomId: roomId={}", roomId);
-
         ChangeStreamOptions options = ChangeStreamOptions.builder()
                 .filter(Aggregation.newAggregation(
                         Aggregation.match(Criteria.where("operationType").is(OperationType.INSERT.getValue())),
@@ -38,8 +34,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                         Aggregation.match(Criteria.where("fullDocument.roomId").is(roomId)) // 해당 roomId와 일치하는 데이터만
                 ))
                 .build();
-
-        log.info("options: {}", options);
 
         return chatFluxMapper.toChatMessageResponseDto(
                 reactiveMongoTemplate.changeStream("chatMessage", options, Document.class)

--- a/src/main/java/com/promptoven/chatservice/application/ChatMessageServiceImpl.java
+++ b/src/main/java/com/promptoven/chatservice/application/ChatMessageServiceImpl.java
@@ -41,7 +41,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                         .map(document -> ChatMessageDocument.builder()
                                 .id(document.get("_id", ObjectId.class).toString())
                                 .roomId(document.getString("roomId"))
-                                .senderUuid(document.getString("senderId"))
+                                .senderUuid(document.getString("senderUuid"))
                                 .messageType(document.getString("messageType"))
                                 .message(document.getString("message"))
                                 .createdAt(LocalDateTime.ofInstant(document.getDate("createdAt").toInstant(),

--- a/src/main/java/com/promptoven/chatservice/application/ChatService.java
+++ b/src/main/java/com/promptoven/chatservice/application/ChatService.java
@@ -2,14 +2,20 @@ package com.promptoven.chatservice.application;
 
 import com.promptoven.chatservice.document.ChatMessageDocument;
 import com.promptoven.chatservice.dto.in.CreateRoomRequestDto;
+import com.promptoven.chatservice.dto.in.PrevMessageRequestDto;
 import com.promptoven.chatservice.dto.in.SendMessageDto;
+import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import com.promptoven.chatservice.dto.out.CreateRoomResponseDto;
+import com.promptoven.chatservice.global.common.utils.CursorPage;
 import reactor.core.publisher.Mono;
 
 public interface ChatService {
+
     CreateRoomResponseDto createChatRoom(CreateRoomRequestDto createRoomRequestDto);
 
     Mono<ChatMessageDocument> sendMessage(SendMessageDto sendMessageDto);
+
+    CursorPage<ChatMessageResponseDto> getPrevMessages(PrevMessageRequestDto prevMessageRequestDto);
 }
 
 

--- a/src/main/java/com/promptoven/chatservice/application/ChatServiceImpl.java
+++ b/src/main/java/com/promptoven/chatservice/application/ChatServiceImpl.java
@@ -4,11 +4,15 @@ import com.promptoven.chatservice.document.ChatMessageDocument;
 import com.promptoven.chatservice.document.ChatRoomDocument;
 import com.promptoven.chatservice.document.mapper.ChatDocumentMapper;
 import com.promptoven.chatservice.dto.in.CreateRoomRequestDto;
+import com.promptoven.chatservice.dto.in.PrevMessageRequestDto;
 import com.promptoven.chatservice.dto.in.SendMessageDto;
 import com.promptoven.chatservice.dto.mapper.ChatDtoMapper;
+import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import com.promptoven.chatservice.dto.out.CreateRoomResponseDto;
+import com.promptoven.chatservice.global.common.utils.CursorPage;
 import com.promptoven.chatservice.infrastructure.MongoChatMessageRepository;
 import com.promptoven.chatservice.infrastructure.MongoChatRepository;
+import com.promptoven.chatservice.infrastructure.MongoCustomChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -21,6 +25,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatDocumentMapper chatDocumentMapper;
     private final MongoChatRepository mongoChatRepository;
     private final MongoChatMessageRepository mongoChatMessageRepository;
+    private final MongoCustomChatRepository mongoCustomChatRepository;
 
     @Override
     public CreateRoomResponseDto createChatRoom(CreateRoomRequestDto createRoomRequestDto) {
@@ -34,5 +39,10 @@ public class ChatServiceImpl implements ChatService {
     @Override
     public Mono<ChatMessageDocument> sendMessage(SendMessageDto sendMessageDto) {
         return mongoChatMessageRepository.save(chatDtoMapper.toChatMessageDocument(sendMessageDto));
+    }
+
+    @Override
+    public CursorPage<ChatMessageResponseDto> getPrevMessages(PrevMessageRequestDto prevMessageRequestDto) {
+        return mongoCustomChatRepository.getPrevMessages(prevMessageRequestDto);
     }
 }

--- a/src/main/java/com/promptoven/chatservice/document/mapper/ChatDocumentMapper.java
+++ b/src/main/java/com/promptoven/chatservice/document/mapper/ChatDocumentMapper.java
@@ -1,6 +1,8 @@
 package com.promptoven.chatservice.document.mapper;
 
+import com.promptoven.chatservice.document.ChatMessageDocument;
 import com.promptoven.chatservice.document.ChatRoomDocument;
+import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import com.promptoven.chatservice.dto.out.CreateRoomResponseDto;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +15,17 @@ public class ChatDocumentMapper {
                 .roomName(chatRoomDocument.getChatRoomName())
                 .createdAt(chatRoomDocument.getCreatedAt())
                 .updatedAt(chatRoomDocument.getUpdatedAt())
+                .build();
+    }
+
+    public ChatMessageResponseDto toChatMessageResponseDto(ChatMessageDocument chatMessageDocument) {
+        return ChatMessageResponseDto.builder()
+                .id(chatMessageDocument.getId())
+                .roomId(chatMessageDocument.getRoomId())
+                .senderUuid(chatMessageDocument.getSenderUuid())
+                .message(chatMessageDocument.getMessage())
+                .createdAt(chatMessageDocument.getCreatedAt())
+                .updatedAt(chatMessageDocument.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/promptoven/chatservice/document/mapper/ChatFluxMapper.java
+++ b/src/main/java/com/promptoven/chatservice/document/mapper/ChatFluxMapper.java
@@ -2,16 +2,13 @@ package com.promptoven.chatservice.document.mapper;
 
 import com.promptoven.chatservice.document.ChatMessageDocument;
 import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
-@Slf4j
 @Component
 public class ChatFluxMapper {
 
     public Flux<ChatMessageResponseDto> toChatMessageResponseDto(Flux<ChatMessageDocument> chatMessageDocumentFlux) {
-        log.info("chatMessageEntityFlux: {}", chatMessageDocumentFlux);
         return chatMessageDocumentFlux.map(chatMessageEntity ->
                 ChatMessageResponseDto.builder()
                         .id(chatMessageEntity.getId())
@@ -19,8 +16,8 @@ public class ChatFluxMapper {
                         .messageType(chatMessageEntity.getMessageType())
                         .message(chatMessageEntity.getMessage())
                         .senderUuid(chatMessageEntity.getSenderUuid())
-                        .createdAt(chatMessageEntity.getCreatedAt().toString())
-                        .updatedAt(chatMessageEntity.getUpdatedAt().toString())
+                        .createdAt(chatMessageEntity.getCreatedAt())
+                        .updatedAt(chatMessageEntity.getUpdatedAt())
                         .build()
         );
     }

--- a/src/main/java/com/promptoven/chatservice/dto/in/ChatRoomDto.java
+++ b/src/main/java/com/promptoven/chatservice/dto/in/ChatRoomDto.java
@@ -1,6 +1,5 @@
 package com.promptoven.chatservice.dto.in;
 
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/promptoven/chatservice/dto/in/CreateRoomRequestDto.java
+++ b/src/main/java/com/promptoven/chatservice/dto/in/CreateRoomRequestDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CreateRoomRequestDto {
+
     private String hostUserUuid;
     private String inviteUserUuid;
     private String roomName;

--- a/src/main/java/com/promptoven/chatservice/dto/in/PrevMessageRequestDto.java
+++ b/src/main/java/com/promptoven/chatservice/dto/in/PrevMessageRequestDto.java
@@ -1,0 +1,25 @@
+package com.promptoven.chatservice.dto.in;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+public class PrevMessageRequestDto {
+
+    private String roomId;
+    private String lastObjectId;
+    private Integer pageSize;
+    private Integer page;
+
+    @Builder
+    public PrevMessageRequestDto(String roomId, String lastObjectId, Integer pageSize, Integer page) {
+        this.roomId = roomId;
+        this.lastObjectId = lastObjectId;
+        this.pageSize = pageSize;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/promptoven/chatservice/dto/in/SendMessageDto.java
+++ b/src/main/java/com/promptoven/chatservice/dto/in/SendMessageDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SendMessageDto {
+
     private String roomId;
     private String messageType;
     private String message;

--- a/src/main/java/com/promptoven/chatservice/dto/mapper/ChatDtoMapper.java
+++ b/src/main/java/com/promptoven/chatservice/dto/mapper/ChatDtoMapper.java
@@ -9,8 +9,6 @@ import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
 import com.promptoven.chatservice.dto.out.CreateRoomResponseDto;
 import com.promptoven.chatservice.vo.out.ChatMessageResponseVo;
 import com.promptoven.chatservice.vo.out.CreateRoomResponseVo;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
@@ -53,7 +51,8 @@ public class ChatDtoMapper {
                 .build();
     }
 
-    public Flux<ChatMessageResponseVo> toChatMessageResponseVo(Flux<ChatMessageResponseDto> chatMessageResponseDtoFlux) {
+    public Flux<ChatMessageResponseVo> toChatMessageResponseVo(
+            Flux<ChatMessageResponseDto> chatMessageResponseDtoFlux) {
         return chatMessageResponseDtoFlux.map(chatMessageDocument ->
                 ChatMessageResponseVo.builder()
                         .id(chatMessageDocument.getId())
@@ -66,4 +65,17 @@ public class ChatDtoMapper {
                         .build()
         );
     }
+
+    public ChatMessageResponseVo toChatMessageResponseVo(ChatMessageResponseDto chatMessageResponseDto) {
+        return ChatMessageResponseVo.builder()
+                .id(chatMessageResponseDto.getId())
+                .roomId(chatMessageResponseDto.getRoomId())
+                .messageType(chatMessageResponseDto.getMessageType())
+                .message(chatMessageResponseDto.getMessage())
+                .senderUuid(chatMessageResponseDto.getSenderUuid())
+                .createdAt(chatMessageResponseDto.getCreatedAt())
+                .updatedAt(chatMessageResponseDto.getUpdatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/com/promptoven/chatservice/dto/out/ChatMessageResponseDto.java
+++ b/src/main/java/com/promptoven/chatservice/dto/out/ChatMessageResponseDto.java
@@ -1,5 +1,6 @@
 package com.promptoven.chatservice.dto.out;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,17 +8,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ChatMessageResponseDto {
+
     private String id;
     private String roomId;
     private String messageType;
     private String message;
     private String senderUuid;
-    private String createdAt;
-    private String updatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     @Builder
     public ChatMessageResponseDto(String id, String roomId, String messageType, String message, String senderUuid,
-            String createdAt, String updatedAt) {
+            LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.roomId = roomId;
         this.messageType = messageType;

--- a/src/main/java/com/promptoven/chatservice/global/common/utils/CursorPage.java
+++ b/src/main/java/com/promptoven/chatservice/global/common/utils/CursorPage.java
@@ -1,47 +1,31 @@
-//package com.promptoven.chatservice.global.common.utils;
-//
-//import com.promptoven.reviewReadService.dto.out.ReviewOutPaginationDto;
-//import com.promptoven.reviewReadService.vo.out.ReadResponseVo;
-//import java.time.LocalDateTime;
-//import java.util.List;
-//import lombok.Builder;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//
-//@Getter
-//@NoArgsConstructor
-//public class CursorPage<T> {
-//
-//    private List<T> content;
-//    private LocalDateTime lastCreatedAt;
-//    private String lastId;
-//    private Boolean hasNext;
-//    private Integer pageSize;
-//    private Integer page;
-//
-//    public boolean hasNext() {
-//        return lastId != null;
-//    }
-//
-//    @Builder
-//    public CursorPage(List<T> content, String lastId, LocalDateTime lastCreatedAt, Boolean hasNext, Integer pageSize,
-//            Integer page) {
-//        this.content = content;
-//        this.lastCreatedAt = lastCreatedAt;
-//        this.lastId = lastId;
-//        this.hasNext = hasNext;
-//        this.pageSize = pageSize;
-//        this.page = page;
-//    }
-//
-//    public static CursorPage<ReadResponseVo> toCursorPage(ReviewOutPaginationDto cursorPage) {
-//        return CursorPage.<ReadResponseVo>builder()
-//                .content(ReadResponseVo.toVoList(cursorPage.getReviewResponseDtoList()))
-//                .lastCreatedAt(cursorPage.getLastCreatedAt())
-//                .lastId(cursorPage.getLastId())
-//                .hasNext(cursorPage.getHasNext())
-//                .pageSize(cursorPage.getPageSize())
-//                .page(cursorPage.getPage())
-//                .build();
-//    }
-//}
+package com.promptoven.chatservice.global.common.utils;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(force = true)
+public class CursorPage<T> {
+
+    private List<T> content;
+    private String lastObjectId;
+    private Boolean hasNext;
+    private Integer pageSize;
+    private Integer page;
+
+    public boolean hasNext() {
+        return lastObjectId != null;
+    }
+
+    @Builder
+    public CursorPage(List<T> content, String lastObjectId, Boolean hasNext, Integer pageSize,
+            Integer page) {
+        this.content = content;
+        this.lastObjectId = lastObjectId;
+        this.hasNext = hasNext;
+        this.pageSize = pageSize;
+        this.page = page;
+    }
+}

--- a/src/main/java/com/promptoven/chatservice/infrastructure/CustomChatRepositoryImpl.java
+++ b/src/main/java/com/promptoven/chatservice/infrastructure/CustomChatRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.promptoven.chatservice.infrastructure;
+
+import com.promptoven.chatservice.document.ChatMessageDocument;
+import com.promptoven.chatservice.document.mapper.ChatDocumentMapper;
+import com.promptoven.chatservice.dto.in.PrevMessageRequestDto;
+import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
+import com.promptoven.chatservice.global.common.utils.CursorPage;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomChatRepositoryImpl implements MongoCustomChatRepository {
+
+    private final MongoTemplate mongoTemplate;
+    private final ChatDocumentMapper chatDocumentMapper;
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 0;
+
+    @Override
+    public CursorPage<ChatMessageResponseDto> getPrevMessages(PrevMessageRequestDto prevMessageRequestDto) {
+
+        String roomId = prevMessageRequestDto.getRoomId();
+        String lastObjectId = prevMessageRequestDto.getLastObjectId();
+        int pageSize = Optional.ofNullable(prevMessageRequestDto.getPageSize()).orElse(DEFAULT_PAGE_SIZE);
+        Integer page = Optional.ofNullable(prevMessageRequestDto.getPage()).orElse(DEFAULT_PAGE_NUMBER);
+
+        Query query = new Query();
+
+        // 필터: productUuid
+        if (roomId != null) {
+            query.addCriteria(Criteria.where("roomId").is(roomId));
+        }
+
+        // 페이징 커서 설정
+        if (lastObjectId != null && !lastObjectId.isEmpty()) {
+            query.addCriteria(Criteria.where("_id").lt(lastObjectId));
+        }
+
+        // 정렬 및 제한
+        query.with(Sort.by(Sort.Direction.DESC, "_id"));
+        query.limit(pageSize + 1);  // 다음 페이지가 있는지 확인하기 위해 1개의 추가 데이터를 요청
+
+        List<ChatMessageDocument> chatMessages = mongoTemplate.find(query, ChatMessageDocument.class);
+
+        String nextObjectId = null;
+        boolean hasNext = false;
+
+        // 다음 페이지가 있는지 확인하고, 결과 리스트를 페이지 사이즈에 맞게 조정
+        if (chatMessages.size() > pageSize) {
+            hasNext = true;
+            chatMessages = chatMessages.subList(0, pageSize);
+            nextObjectId = chatMessages.get(pageSize - 1).getId();
+        }
+
+        List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessages.stream()
+                .map(chatDocumentMapper::toChatMessageResponseDto)
+                .collect(Collectors.toList());
+
+        return CursorPage.<ChatMessageResponseDto>builder()
+                .content(chatMessageResponseDtoList)
+                .lastObjectId(nextObjectId)
+                .hasNext(hasNext)
+                .page(page)
+                .pageSize(pageSize)
+                .build();
+    }
+}

--- a/src/main/java/com/promptoven/chatservice/infrastructure/MongoCustomChatRepository.java
+++ b/src/main/java/com/promptoven/chatservice/infrastructure/MongoCustomChatRepository.java
@@ -1,0 +1,11 @@
+package com.promptoven.chatservice.infrastructure;
+
+import com.promptoven.chatservice.dto.in.PrevMessageRequestDto;
+import com.promptoven.chatservice.dto.out.ChatMessageResponseDto;
+import com.promptoven.chatservice.global.common.utils.CursorPage;
+
+
+public interface MongoCustomChatRepository {
+
+    CursorPage<ChatMessageResponseDto> getPrevMessages(PrevMessageRequestDto prevMessageRequestDto);
+}

--- a/src/main/java/com/promptoven/chatservice/presentation/ChatMessageReactiveController.java
+++ b/src/main/java/com/promptoven/chatservice/presentation/ChatMessageReactiveController.java
@@ -20,7 +20,7 @@ public class ChatMessageReactiveController {
     private final ChatDtoMapper chatDtoMapper;
     private final ChatMessageService chatMessageService;
 
-    @GetMapping(value = "/{roomId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @GetMapping(value = "/new/{roomId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ChatMessageResponseVo> getChatByRoomId(@PathVariable String roomId) {
 
         Flux<ChatMessageResponseDto> chatMessageResponseDtoFlux = chatMessageService.getMessageByRoomId(roomId);

--- a/src/main/java/com/promptoven/chatservice/vo/in/CreateRoomRequestVo.java
+++ b/src/main/java/com/promptoven/chatservice/vo/in/CreateRoomRequestVo.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public class CreateRoomRequestVo {
+
     private String hostUserUuid;
     private String inviteUserUuid;
     private String roomName;

--- a/src/main/java/com/promptoven/chatservice/vo/in/SendMessageVo.java
+++ b/src/main/java/com/promptoven/chatservice/vo/in/SendMessageVo.java
@@ -1,11 +1,10 @@
 package com.promptoven.chatservice.vo.in;
 
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class SendMessageVo {
+
     private String roomId;
     private String messageType;
     private String message;

--- a/src/main/java/com/promptoven/chatservice/vo/mapper/ChatVoMapper.java
+++ b/src/main/java/com/promptoven/chatservice/vo/mapper/ChatVoMapper.java
@@ -4,7 +4,6 @@ import com.promptoven.chatservice.dto.in.CreateRoomRequestDto;
 import com.promptoven.chatservice.dto.in.SendMessageDto;
 import com.promptoven.chatservice.vo.in.CreateRoomRequestVo;
 import com.promptoven.chatservice.vo.in.SendMessageVo;
-import com.promptoven.chatservice.vo.out.CreateRoomResponseVo;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/promptoven/chatservice/vo/out/ChatMessageResponseVo.java
+++ b/src/main/java/com/promptoven/chatservice/vo/out/ChatMessageResponseVo.java
@@ -1,5 +1,6 @@
 package com.promptoven.chatservice.vo.out;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,17 +8,18 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ChatMessageResponseVo {
+
     private String id;
     private String roomId;
     private String messageType;
     private String message;
     private String senderUuid;
-    private String createdAt;
-    private String updatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     @Builder
     public ChatMessageResponseVo(String id, String roomId, String messageType, String message, String senderUuid,
-            String createdAt, String updatedAt) {
+            LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.roomId = roomId;
         this.messageType = messageType;

--- a/src/main/java/com/promptoven/chatservice/vo/out/CreateRoomResponseVo.java
+++ b/src/main/java/com/promptoven/chatservice/vo/out/CreateRoomResponseVo.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CreateRoomResponseVo {
+
     private String roomId;
     private String roomName;
     private LocalDateTime createdAt;


### PR DESCRIPTION
- 기능 : 페이지네이션 처리하여 채팅방 입장 시 이전 채팅 내역 불러옴
- 이슈 : X
- 현재 기본 페이지네이션 사이즈는 데이터 20개. 프론트에서 요구하는대로 바꿀 예정